### PR TITLE
fix: correct spelling of "container" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Categorize a prompt into a Simpson's quote.
 
 ## Development
 
-We attempt to keep the dev contaienr up to date.
+We attempt to keep the dev container up to date.


### PR DESCRIPTION
Fixes #5: Corrected the spelling of "contaienr" to "container" in the development section of README.md.

Generated with [Claude Code](https://claude.ai/code)