### PR TITLE
refactor: remove QuoteResult, add utility functions for APISearchResult

### DIFF
--- a/pkg/frinkiac/command.go
+++ b/pkg/frinkiac/command.go
@@ -47,10 +47,22 @@ func (o *Command) Run(ctx context.Context) error {
 		if len(results) > 0 {
 			// Use the first result
 			result := results[0]
-			fmt.Printf("   Found screen cap: Season %s, Episode %s, ID %s\n", result.Season, result.Episode, result.ID)
+
+			// Extract season and episode using the new utility function
+			season, episode, err := http.GetSeasonAndEpisode(result)
+			if err != nil {
+				fmt.Printf("   Error parsing season/episode: %v\n", err)
+				continue
+			}
+
+			seasonStr := fmt.Sprintf("S%02d", season)
+			episodeStr := fmt.Sprintf("E%02d", episode)
+			idStr := fmt.Sprintf("%d", result.Timestamp)
+
+			fmt.Printf("   Found screen cap: Season %s, Episode %s, ID %s\n", seasonStr, episodeStr, idStr)
 
 			// Get the screen cap
-			screenCap, err := http.GetScreenCap(ctx, client, config, result.Season, result.Episode, result.ID)
+			screenCap, err := http.GetScreenCap(ctx, client, config, seasonStr, episodeStr, idStr)
 			if err != nil {
 				fmt.Printf("   Error getting screen cap: %v\n", err)
 				continue

--- a/pkg/frinkiac/command.go
+++ b/pkg/frinkiac/command.go
@@ -48,8 +48,7 @@ func (o *Command) Run(ctx context.Context) error {
 			// Use the first result
 			result := results[0]
 
-			// Extract season and episode using the new utility function
-			season, episode, err := http.GetSeasonAndEpisode(result)
+			season, episode, err := http.GetSeasonAndEpisode(result.EpisodID)
 			if err != nil {
 				fmt.Printf("   Error parsing season/episode: %v\n", err)
 				continue
@@ -58,7 +57,7 @@ func (o *Command) Run(ctx context.Context) error {
 			seasonStr := fmt.Sprintf("S%02d", season)
 			episodeStr := fmt.Sprintf("E%02d", episode)
 
-			fmt.Printf("   Found screen cap: Season %s, Episode %s, ID %d\n", seasonStr, episodeStr, result.Timestamp)
+			fmt.Printf("   Found screen cap: Season %s, Episode %s, ID %s\n", seasonStr, episodeStr, result.Timestamp)
 
 			// Get the screen cap
 			screenCap, err := http.GetScreenCap(ctx, client, config, seasonStr, episodeStr, result.Timestamp)

--- a/pkg/frinkiac/command.go
+++ b/pkg/frinkiac/command.go
@@ -57,12 +57,11 @@ func (o *Command) Run(ctx context.Context) error {
 
 			seasonStr := fmt.Sprintf("S%02d", season)
 			episodeStr := fmt.Sprintf("E%02d", episode)
-			idStr := fmt.Sprintf("%d", result.Timestamp)
 
-			fmt.Printf("   Found screen cap: Season %s, Episode %s, ID %s\n", seasonStr, episodeStr, idStr)
+			fmt.Printf("   Found screen cap: Season %s, Episode %s, ID %d\n", seasonStr, episodeStr, result.Timestamp)
 
 			// Get the screen cap
-			screenCap, err := http.GetScreenCap(ctx, client, config, seasonStr, episodeStr, idStr)
+			screenCap, err := http.GetScreenCap(ctx, client, config, seasonStr, episodeStr, result.Timestamp)
 			if err != nil {
 				fmt.Printf("   Error getting screen cap: %v\n", err)
 				continue

--- a/pkg/frinkiac/command.go
+++ b/pkg/frinkiac/command.go
@@ -60,7 +60,7 @@ func (o *Command) Run(ctx context.Context) error {
 			fmt.Printf("   Found screen cap: Season %s, Episode %s, ID %s\n", seasonStr, episodeStr, result.Timestamp)
 
 			// Get the screen cap
-			screenCap, err := http.GetScreenCap(ctx, client, config, seasonStr, episodeStr, result.Timestamp)
+			screenCap, err := http.GetScreenCap(ctx, client, config, season, episode, result.Timestamp)
 			if err != nil {
 				fmt.Printf("   Error getting screen cap: %v\n", err)
 				continue

--- a/pkg/frinkiac/http/client_test.go
+++ b/pkg/frinkiac/http/client_test.go
@@ -38,7 +38,7 @@ func ExampleGetQuote() {
 			continue
 		}
 
-		imagePath, err := GetImagePath(result)
+		imagePath, err := GetImagePath(result.EpisodID, result.Timestamp)
 		if err != nil {
 			fmt.Printf("Error getting image path for result %d: %v\n", i+1, err)
 			continue
@@ -61,7 +61,7 @@ func ExampleGetScreenCap() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := GetScreenCap(ctx, client, config, "S09", "E22", Timestamp("202334"))
+	result, err := GetScreenCap(ctx, client, config, 9, 22, Timestamp("202334"))
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return
@@ -187,7 +187,7 @@ func TestParseAPIResponse(t *testing.T) {
 	assert.Equal(t, 1, episode, "First result episode should be 1")
 
 	// Test GetImagePath function with the first result
-	imagePath, err := GetImagePath(firstResult)
+	imagePath, err := GetImagePath(firstResult.EpisodID, firstResult.Timestamp)
 	require.NoError(t, err, "Failed to get image path from first result")
 	expectedPath := fmt.Sprintf("/img/S16E01/%s/medium.jpg", firstResult.Timestamp)
 	assert.Equal(t, expectedPath, imagePath, "Image path should match expected format")
@@ -204,7 +204,7 @@ func TestParseAPIResponse(t *testing.T) {
 			assert.Equal(t, 10, season, "S10E19 result season should be 10")
 			assert.Equal(t, 19, episode, "S10E19 result episode should be 19")
 
-			imagePath, err := GetImagePath(apiResults[i])
+			imagePath, err := GetImagePath(apiResults[i].EpisodID, apiResults[i].Timestamp)
 			require.NoError(t, err, "Failed to get image path from S10E19 result")
 			expectedPath := fmt.Sprintf("/img/S10E19/%s/medium.jpg", apiResults[i].Timestamp)
 			assert.Equal(t, expectedPath, imagePath, "S10E19 image path should match expected format")
@@ -272,26 +272,29 @@ func TestGetSeasonAndEpisode(t *testing.T) {
 func TestGetImagePath(t *testing.T) {
 	tests := []struct {
 		name        string
-		result      SearchResult
+		episodeID   EpisodeID
+		timestamp   Timestamp
 		expectError bool
 		expected    string
 	}{
 		{
 			name:        "Valid result",
-			result:      SearchResult{EpisodID: "S16E01", Timestamp: "123456"},
+			episodeID:   "S16E01",
+			timestamp:   "123456",
 			expectError: false,
 			expected:    "/img/S16E01/123456/medium.jpg",
 		},
 		{
 			name:        "Invalid episode format",
-			result:      SearchResult{EpisodID: "S16E", Timestamp: "123456"},
+			episodeID:   "S16E",
+			timestamp:   "123456",
 			expectError: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			imagePath, err := GetImagePath(tt.result)
+			imagePath, err := GetImagePath(tt.episodeID, tt.timestamp)
 
 			if tt.expectError {
 				assert.Error(t, err, "Expected error for invalid input")

--- a/pkg/frinkiac/http/client_test.go
+++ b/pkg/frinkiac/http/client_test.go
@@ -61,7 +61,7 @@ func ExampleGetScreenCap() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	result, err := GetScreenCap(ctx, client, config, "S09", "E22", "202334")
+	result, err := GetScreenCap(ctx, client, config, "S09", "E22", 202334)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 		return

--- a/pkg/frinkiac/http/quote.go
+++ b/pkg/frinkiac/http/quote.go
@@ -75,15 +75,15 @@ func GetSeasonAndEpisode(episodeID EpisodeID) (season int, episode int, err erro
 	return season, episode, nil
 }
 
-// GetImagePath constructs the image path for a SearchResult
-func GetImagePath(result SearchResult) (string, error) {
+// GetImagePath constructs the image path for the given episodeID and timestamp
+func GetImagePath(episodeID EpisodeID, timestamp Timestamp) (string, error) {
 	// Validate the episode format first
-	episodeStr := string(result.EpisodID)
+	episodeStr := string(episodeID)
 	if err := validateEpisodeFormat(episodeStr); err != nil {
 		return "", err
 	}
 
-	return fmt.Sprintf("/img/%s/%s/medium.jpg", result.EpisodID, result.Timestamp), nil
+	return fmt.Sprintf("/img/%s/%s/medium.jpg", episodeID, timestamp), nil
 }
 
 // hasClass checks if a node has a specific class

--- a/pkg/frinkiac/http/screencap.go
+++ b/pkg/frinkiac/http/screencap.go
@@ -55,16 +55,20 @@ type APICaption struct {
 }
 
 // GetScreenCap gets a screen cap from Frinkiac
-func GetScreenCap(ctx context.Context, client *http.Client, config Config, season, episode string, timestamp Timestamp) (*ScreenCapResult, error) {
+func GetScreenCap(ctx context.Context, client *http.Client, config Config, season, episode int, timestamp Timestamp) (*ScreenCapResult, error) {
 	// Convert timestamp to string for internal functions
 	id := string(timestamp)
 
+	// Convert season and episode to strings for internal functions
+	seasonStr := fmt.Sprintf("S%02d", season)
+	episodeStr := fmt.Sprintf("E%02d", episode)
+
 	// First try the JSON API endpoint
-	result, err := getScreenCapFromAPI(ctx, client, config, season, episode, id)
+	result, err := getScreenCapFromAPI(ctx, client, config, seasonStr, episodeStr, id)
 	if err != nil {
 		// If the API endpoint fails, fall back to the HTML endpoint
-		log.Info().Str("season", season).Str("episode", episode).Str("id", id).Msg("API endpoint failed, falling back to HTML endpoint")
-		return getScreenCapFromHTML(ctx, client, config, season, episode, id)
+		log.Info().Str("season", seasonStr).Str("episode", episodeStr).Str("id", id).Msg("API endpoint failed, falling back to HTML endpoint")
+		return getScreenCapFromHTML(ctx, client, config, seasonStr, episodeStr, id)
 	}
 	return result, nil
 }

--- a/pkg/frinkiac/http/screencap.go
+++ b/pkg/frinkiac/http/screencap.go
@@ -55,9 +55,9 @@ type APICaption struct {
 }
 
 // GetScreenCap gets a screen cap from Frinkiac
-func GetScreenCap(ctx context.Context, client *http.Client, config Config, season, episode string, timestamp int) (*ScreenCapResult, error) {
+func GetScreenCap(ctx context.Context, client *http.Client, config Config, season, episode string, timestamp Timestamp) (*ScreenCapResult, error) {
 	// Convert timestamp to string for internal functions
-	id := fmt.Sprintf("%d", timestamp)
+	id := string(timestamp)
 
 	// First try the JSON API endpoint
 	result, err := getScreenCapFromAPI(ctx, client, config, season, episode, id)

--- a/pkg/frinkiac/http/screencap.go
+++ b/pkg/frinkiac/http/screencap.go
@@ -55,7 +55,10 @@ type APICaption struct {
 }
 
 // GetScreenCap gets a screen cap from Frinkiac
-func GetScreenCap(ctx context.Context, client *http.Client, config Config, season, episode, id string) (*ScreenCapResult, error) {
+func GetScreenCap(ctx context.Context, client *http.Client, config Config, season, episode string, timestamp int) (*ScreenCapResult, error) {
+	// Convert timestamp to string for internal functions
+	id := fmt.Sprintf("%d", timestamp)
+
 	// First try the JSON API endpoint
 	result, err := getScreenCapFromAPI(ctx, client, config, season, episode, id)
 	if err != nil {


### PR DESCRIPTION
Refactors the frinkiac/http package to remove QuoteResult and replace it with APISearchResult, along with adding utility functions as requested.

## Changes
- Remove QuoteResult struct from frinkiac/http package
- Update GetQuote to return []APISearchResult directly
- Add GetSeasonAndEpisode function to extract season/episode numbers
- Add GetImagePath function to construct image paths
- Update command.go to use new utility functions
- Update tests with comprehensive coverage for new functions
- Maintain backward compatibility of functionality

Resolves #24

Generated with [Claude Code](https://claude.ai/code)